### PR TITLE
Feature/refactor

### DIFF
--- a/addStyles.js
+++ b/addStyles.js
@@ -1,206 +1,148 @@
-/*
-	MIT License http://www.opensource.org/licenses/mit-license.php
-	Author Tobias Koppers @sokra
-*/
-var stylesInDom = {},
-	memoize = function(fn) {
-		var memo;
-		return function () {
-			if (typeof memo === "undefined") memo = fn.apply(this, arguments);
-			return memo;
-		};
-	},
-	isOldIE = memoize(function() {
-		return /msie [6-9]\b/.test(window.navigator.userAgent.toLowerCase());
-	}),
-	getHeadElement = memoize(function () {
-		return document.head || document.getElementsByTagName("head")[0];
-	}),
-	singletonElement = null,
-	singletonCounter = 0,
-	styleElementsInsertedAtTop = [];
+define(function (require, exports, module) {/*
+ MIT License http://www.opensource.org/licenses/mit-license.php
+ Author Tobias Koppers @sokra
+ */
 
-module.exports = function(list, options) {
-	if(typeof DEBUG !== "undefined" && DEBUG) {
-		if(typeof document !== "object") throw new Error("The style-loader cannot be used in a non-browser environment");
+	var stylesInDom = {},
+		playerStyleElements = {},
+		memoize = function(fn) {
+			var memo;
+			return function () {
+				if (typeof memo === "undefined") memo = fn.apply(this, arguments);
+				return memo;
+			};
+		},
+		getHeadElement = memoize(function () {
+			return document.head || document.getElementsByTagName("head")[0];
+		});
+
+	module.exports = {
+		style: style,
+		clear: clear
+	};
+
+	function style (playerId, list) {
+		addStylesToDom(playerId, listToStyles(list));
 	}
 
-	options = options || {};
-	// Force single-tag solution on IE6-9, which has a hard limit on the # of <style>
-	// tags it will allow on a page
-	if (typeof options.singleton === "undefined") options.singleton = isOldIE();
+	function clear (playerId) {
+		var playerStyles = stylesInDom[playerId];
+		if (!playerStyles) {
+			return;
+		}
+		var styleKeys = Object.keys(playerStyles);
+		for (var i = 0; i < styleKeys.length; i += 1) {
+			var styleObj = playerStyles[styleKeys[i]];
+			for (var j = 0; j < styleObj.parts.length; j += 1) {
+				styleObj.parts[j]();
+			}
+		}
+		delete stylesInDom[playerId];
+	}
 
-	// By default, add <style> tags to the bottom of <head>.
-	if (typeof options.insertAt === "undefined") options.insertAt = "bottom";
-
-	var styles = listToStyles(list);
-	addStylesToDom(styles, options);
-
-	return function update(newList) {
-		var mayRemove = [];
+	function addStylesToDom(id, styles) {
 		for(var i = 0; i < styles.length; i++) {
 			var item = styles[i];
-			var domStyle = stylesInDom[item.id];
-			domStyle.refs--;
-			mayRemove.push(domStyle);
-		}
-		if(newList) {
-			var newStyles = listToStyles(newList);
-			addStylesToDom(newStyles, options);
-		}
-		for(var i = 0; i < mayRemove.length; i++) {
-			var domStyle = mayRemove[i];
-			if(domStyle.refs === 0) {
-				for(var j = 0; j < domStyle.parts.length; j++)
-					domStyle.parts[j]();
-				delete stylesInDom[domStyle.id];
+			var domStyle = (stylesInDom[id] || {})[item.id];
+			if(domStyle) {
+				domStyle.refs++;
+				for(var j = 0; j < domStyle.parts.length; j++) {
+					domStyle.parts[j](item.parts[j]);
+				}
+				for(; j < item.parts.length; j++) {
+					domStyle.parts.push(addStyle(id, item.parts[j]));
+				}
+			} else {
+				var parts = [];
+				for(var j = 0; j < item.parts.length; j++) {
+					parts.push(addStyle(id, item.parts[j]));
+				}
+				stylesInDom[id] = stylesInDom[id] || {};
+				stylesInDom[id][item.id] = {id: item.id, refs: 1, parts: parts};
 			}
 		}
-	};
-}
+	}
 
-function addStylesToDom(styles, options) {
-	for(var i = 0; i < styles.length; i++) {
-		var item = styles[i];
-		var domStyle = stylesInDom[item.id];
-		if(domStyle) {
-			domStyle.refs++;
-			for(var j = 0; j < domStyle.parts.length; j++) {
-				domStyle.parts[j](item.parts[j]);
-			}
-			for(; j < item.parts.length; j++) {
-				domStyle.parts.push(addStyle(item.parts[j], options));
-			}
-		} else {
-			var parts = [];
-			for(var j = 0; j < item.parts.length; j++) {
-				parts.push(addStyle(item.parts[j], options));
-			}
-			stylesInDom[item.id] = {id: item.id, refs: 1, parts: parts};
+	function listToStyles(list) {
+		var styles = [];
+		var newStyles = {};
+		for(var i = 0; i < list.length; i++) {
+			var item = list[i];
+			// The id isn't a css selector - it's just used internally
+			var id = item[0];
+			var css = item[1];
+			var media = item[2];
+			var part = {css: css, media: media};
+			if(!newStyles[id])
+				styles.push(newStyles[id] = {id: id, parts: [part]});
+			else
+				newStyles[id].parts.push(part);
 		}
+		return styles;
 	}
-}
 
-function listToStyles(list) {
-	var styles = [];
-	var newStyles = {};
-	for(var i = 0; i < list.length; i++) {
-		var item = list[i];
-		var id = item[0];
-		var css = item[1];
-		var media = item[2];
-		var part = {css: css, media: media};
-		if(!newStyles[id])
-			styles.push(newStyles[id] = {id: id, parts: [part]});
-		else
-			newStyles[id].parts.push(part);
+	function insertStyleElement(styleElement) {
+		getHeadElement().appendChild(styleElement);
 	}
-	return styles;
-}
 
-function insertStyleElement(options, styleElement) {
-	var head = getHeadElement();
-	var lastStyleElementInsertedAtTop = styleElementsInsertedAtTop[styleElementsInsertedAtTop.length - 1];
-	if (options.insertAt === "top") {
-		if(!lastStyleElementInsertedAtTop) {
-			head.insertBefore(styleElement, head.firstChild);
-		} else if(lastStyleElementInsertedAtTop.nextSibling) {
-			head.insertBefore(styleElement, lastStyleElementInsertedAtTop.nextSibling);
-		} else {
-			head.appendChild(styleElement);
+	function createStyleElement() {
+		var styleElement = document.createElement("style");
+		styleElement.type = "text/css";
+		insertStyleElement(styleElement);
+		return styleElement;
+	}
+
+	function addStyle(id, obj) {
+		var styleElement, update, remove;
+		var singleton = playerStyleElements[id];
+
+		if (!singleton) {
+			singleton = playerStyleElements[id] = {
+				element: createStyleElement(),
+				counter: 0
+			};
 		}
-		styleElementsInsertedAtTop.push(styleElement);
-	} else if (options.insertAt === "bottom") {
-		head.appendChild(styleElement);
-	} else {
-		throw new Error("Invalid value for parameter 'insertAt'. Must be 'top' or 'bottom'.");
-	}
-}
 
-function removeStyleElement(styleElement) {
-	styleElement.parentNode.removeChild(styleElement);
-	var idx = styleElementsInsertedAtTop.indexOf(styleElement);
-	if(idx >= 0) {
-		styleElementsInsertedAtTop.splice(idx, 1);
-	}
-}
-
-function createStyleElement(options) {
-	var styleElement = document.createElement("style");
-	styleElement.type = "text/css";
-	insertStyleElement(options, styleElement);
-	return styleElement;
-}
-
-function addStyle(obj, options) {
-	var styleElement, update, remove;
-
-	if (options.singleton) {
-		var styleIndex = singletonCounter++;
-		styleElement = singletonElement || (singletonElement = createStyleElement(options));
+		var styleIndex = singleton.counter++;
+		styleElement = singleton.element;
 		update = applyToSingletonTag.bind(null, styleElement, styleIndex, false);
 		remove = applyToSingletonTag.bind(null, styleElement, styleIndex, true);
-	} else {
-		styleElement = createStyleElement(options);
-		update = applyToTag.bind(null, styleElement);
-		remove = function() {
-			removeStyleElement(styleElement);
+
+		update(obj);
+
+		return function updateStyle(newObj) {
+			if(newObj) {
+				if(newObj.css === obj.css && newObj.media === obj.media)
+					return;
+				update(obj = newObj);
+			} else {
+				remove();
+			}
 		};
 	}
 
-	update(obj);
+	var replaceText = (function () {
+		var textStore = [];
 
-	return function updateStyle(newObj) {
-		if(newObj) {
-			if(newObj.css === obj.css && newObj.media === obj.media)
-				return;
-			update(obj = newObj);
+		return function (index, replacement) {
+			textStore[index] = replacement;
+			return textStore.filter(Boolean).join('\n');
+		};
+	})();
+
+	function applyToSingletonTag(styleElement, index, remove, obj) {
+		var css = remove ? "" : obj.css;
+		if (styleElement.styleSheet) {
+			styleElement.styleSheet.cssText = replaceText(index, css);
 		} else {
-			remove();
-		}
-	};
-}
-
-var replaceText = (function () {
-	var textStore = [];
-
-	return function (index, replacement) {
-		textStore[index] = replacement;
-		return textStore.filter(Boolean).join('\n');
-	};
-})();
-
-function applyToSingletonTag(styleElement, index, remove, obj) {
-	var css = remove ? "" : obj.css;
-
-	if (styleElement.styleSheet) {
-		styleElement.styleSheet.cssText = replaceText(index, css);
-	} else {
-		var cssNode = document.createTextNode(css);
-		var childNodes = styleElement.childNodes;
-		if (childNodes[index]) styleElement.removeChild(childNodes[index]);
-		if (childNodes.length) {
-			styleElement.insertBefore(cssNode, childNodes[index]);
-		} else {
-			styleElement.appendChild(cssNode);
+			var cssNode = document.createTextNode(css);
+			var childNodes = styleElement.childNodes;
+			if (childNodes[index]) styleElement.removeChild(childNodes[index]);
+			if (childNodes.length) {
+				styleElement.insertBefore(cssNode, childNodes[index]);
+			} else {
+				styleElement.appendChild(cssNode);
+			}
 		}
 	}
-}
-
-function applyToTag(styleElement, obj) {
-	var css = obj.css;
-	var media = obj.media;
-
-	if(media) {
-		styleElement.setAttribute("media", media)
-	}
-
-	if(styleElement.styleSheet) {
-		styleElement.styleSheet.cssText = css;
-	} else {
-		while(styleElement.firstChild) {
-			styleElement.removeChild(styleElement.firstChild);
-		}
-		styleElement.appendChild(document.createTextNode(css));
-	}
-}
+});

--- a/addStyles.js
+++ b/addStyles.js
@@ -87,7 +87,7 @@ define(function (require, exports, module) {/*
 	function createStyleElement(playerId) {
 		var styleElement = document.createElement("style");
 		styleElement.type = "text/css";
-		styleElement.setAttribute('data-playerId', playerId);
+		styleElement.setAttribute('data-jwplayer-id', playerId);
 		insertStyleElement(styleElement);
 		return styleElement;
 	}

--- a/addStyles.js
+++ b/addStyles.js
@@ -40,25 +40,24 @@ define(function (require, exports, module) {/*
 		delete stylesInDom[playerId];
 	}
 
-	function addStylesToDom(id, styles) {
+	function addStylesToDom(playerId, styles) {
 		for(var i = 0; i < styles.length; i++) {
 			var item = styles[i];
-			var domStyle = (stylesInDom[id] || {})[item.id];
+			var domStyle = (stylesInDom[playerId] || {})[item.id];
 			if(domStyle) {
-				domStyle.refs++;
 				for(var j = 0; j < domStyle.parts.length; j++) {
 					domStyle.parts[j](item.parts[j]);
 				}
 				for(; j < item.parts.length; j++) {
-					domStyle.parts.push(addStyle(id, item.parts[j]));
+					domStyle.parts.push(addStyle(playerId, item.parts[j]));
 				}
 			} else {
 				var parts = [];
 				for(var j = 0; j < item.parts.length; j++) {
-					parts.push(addStyle(id, item.parts[j]));
+					parts.push(addStyle(playerId, item.parts[j]));
 				}
-				stylesInDom[id] = stylesInDom[id] || {};
-				stylesInDom[id][item.id] = {id: item.id, refs: 1, parts: parts};
+				stylesInDom[playerId] = stylesInDom[playerId] || {};
+				stylesInDom[playerId][item.id] = {id: item.id, parts: parts};
 			}
 		}
 	}
@@ -85,20 +84,21 @@ define(function (require, exports, module) {/*
 		getHeadElement().appendChild(styleElement);
 	}
 
-	function createStyleElement() {
+	function createStyleElement(playerId) {
 		var styleElement = document.createElement("style");
 		styleElement.type = "text/css";
+		styleElement.setAttribute('data-playerId', playerId);
 		insertStyleElement(styleElement);
 		return styleElement;
 	}
 
-	function addStyle(id, obj) {
+	function addStyle(playerId, obj) {
 		var styleElement, update, remove;
-		var singleton = playerStyleElements[id];
+		var singleton = playerStyleElements[playerId];
 
 		if (!singleton) {
-			singleton = playerStyleElements[id] = {
-				element: createStyleElement(),
+			singleton = playerStyleElements[playerId] = {
+				element: createStyleElement(playerId),
 				counter: 0
 			};
 		}

--- a/index.js
+++ b/index.js
@@ -1,21 +1,21 @@
-/*
-	MIT License http://www.opensource.org/licenses/mit-license.php
-	Author Tobias Koppers @sokra
-*/
-var loaderUtils = require("loader-utils"),
-	path = require("path");
-module.exports = function() {};
-module.exports.pitch = function(remainingRequest) {
-	if(this.cacheable) this.cacheable();
-	var query = loaderUtils.parseQuery(this.query);
-	return [
-		"// style-loader: Adds some css to the DOM by adding a <style> tag",
-		"",
-		"// load the styles",
-		"var content = require(" + loaderUtils.stringifyRequest(this, "!!" + remainingRequest) + ");",
-		"if(typeof content === 'string') content = [[module.id, content, '']];",
-		"// add the styles to the DOM",
-		"var update = require(" + loaderUtils.stringifyRequest(this, "!" + path.join(__dirname, "addStyles.js")) + ")(content, " + JSON.stringify(query) + ");",
-		"if(content.locals) module.exports = content.locals;"
-	].join("\n");
-};
+define(function (require, exports, module) {var __filename = module.uri || "", __dirname = __filename.substring(0, __filename.lastIndexOf("/") + 1); /*
+ MIT License http://www.opensource.org/licenses/mit-license.php
+ Author Tobias Koppers @sokra
+ */
+	var loaderUtils = require("loader-utils"),
+		path = require("path");
+	module.exports = function() {};
+	module.exports.pitch = function(remainingRequest) {
+		if(this.cacheable) this.cacheable();
+		return [
+			"// style-loader: Adds some css to the DOM by adding a <style> tag",
+			"",
+			"// load the styles",
+			"var content = require(" + loaderUtils.stringifyRequest(this, "!!" + remainingRequest) + ");",
+			"if(typeof content === 'string') content = [[module.id, content, '']];",
+			"// add the styles to the DOM",
+			"require(" + loaderUtils.stringifyRequest(this, "!" + path.join(__dirname, "addStyles.js")) + ").style(module.id, content);",
+			"if(content.locals) module.exports = content.locals;"
+		].join("\n");
+	};
+});

--- a/index.js
+++ b/index.js
@@ -1,21 +1,20 @@
-define(function (require, exports, module) {var __filename = module.uri || "", __dirname = __filename.substring(0, __filename.lastIndexOf("/") + 1); /*
+ /*
  MIT License http://www.opensource.org/licenses/mit-license.php
  Author Tobias Koppers @sokra
  */
-	var loaderUtils = require("loader-utils"),
-		path = require("path");
+var loaderUtils = require("loader-utils"),
+	path = require("path");
 	module.exports = function() {};
 	module.exports.pitch = function(remainingRequest) {
-		if(this.cacheable) this.cacheable();
-		return [
-			"// style-loader: Adds some css to the DOM by adding a <style> tag",
-			"",
-			"// load the styles",
-			"var content = require(" + loaderUtils.stringifyRequest(this, "!!" + remainingRequest) + ");",
-			"if(typeof content === 'string') content = [[module.id, content, '']];",
-			"// add the styles to the DOM",
-			"require(" + loaderUtils.stringifyRequest(this, "!" + path.join(__dirname, "addStyles.js")) + ").style(module.id, content);",
-			"if(content.locals) module.exports = content.locals;"
-		].join("\n");
-	};
-});
+	if(this.cacheable) this.cacheable();
+	return [
+		"// style-loader: Adds some css to the DOM by adding a <style> tag",
+		"",
+		"// load the styles",
+		"var content = require(" + loaderUtils.stringifyRequest(this, "!!" + remainingRequest) + ");",
+		"if(typeof content === 'string') content = [[module.id, content, '']];",
+		"// add the styles to the DOM",
+		"require(" + loaderUtils.stringifyRequest(this, "!" + path.join(__dirname, "addStyles.js")) + ").style(module.id, content);",
+		"if(content.locals) module.exports = content.locals;"
+	].join("\n");
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-style-loader",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "simplified style loader module for webpack based on style-loader by Tobias Koppers @sokra",
   "scripts": {},
   "repository": {


### PR DESCRIPTION
- Use AMD definition for compatibility with require.js
- Force singleton mode
- Use one style tag per playerId
- Style tags belonging to players are not removed from the page
- Use two-layer hash map to manage styles
  - Top-level map: playerId: { ...selectors }
  - Bottom-level map: selector: 'style'
  - All selectors of the same playerId are placed into the player's map
  - Selectors contain styles which are replaced in the case a the selector already exists
- Remove options since they're unneeded
- Remove unusued code
- Remove reference counting mechanism
  - Did not want to remove styles which were not touched in a style() call
- Add attribute 'data-playerId' to identify styles unique to player instance

JW7-2472

See https://github.com/jwplayer/jwplayer/tree/feature/style-loader-opt for implementation
