### PR TITLE
Use replaceChild() instead of removeChild() and insertBefore()

### DIFF
--- a/addStyles.js
+++ b/addStyles.js
@@ -147,9 +147,9 @@ define(function (require, exports, module) {/*
 		} else {
 			var cssNode = document.createTextNode(css);
 			var childNodes = styleElement.childNodes;
-			if (childNodes[index]) styleElement.removeChild(childNodes[index]);
-			if (childNodes.length) {
-				styleElement.insertBefore(cssNode, childNodes[index]);
+			var child = childNodes[index];
+			if (child) {
+				styleElement.replaceChild(cssNode, child);
 			} else {
 				styleElement.appendChild(cssNode);
 			}


### PR DESCRIPTION
Calling `styleElement.insertBefore(cssNode, undefined);` breaks in Safari. This should fix that.